### PR TITLE
Switch to persistent client object

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -1,6 +1,48 @@
 package client
 
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/codingpa-ws/foxbox/internal/store"
+)
+
 const RuntimeDir = "runtime"
+
+type Client interface {
+	Create(opt *CreateOptions) (name string, err error)
+	Delete(name string, opt *DeleteOptions) (err error)
+	List(opt *ListOptions) (ids []string, err error)
+	Ps(opt *PsOptions) (infos []ProcessInfo, err error)
+	Run(name string, opt *RunOptions) (err error)
+}
+
+type client struct {
+	store *store.Store
+}
+
+func FromStore(store *store.Store) Client {
+	return &client{store}
+}
+
+func FromUser() (Client, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, err
+	}
+	path := filepath.Join(home, ".local", "share", "containers", "foxbox")
+
+	err = os.MkdirAll(path, 0755)
+	if err != nil {
+		return nil, err
+	}
+	store, err := store.New(path)
+	if err != nil {
+		return nil, err
+	}
+
+	return &client{store}, nil
+}
 
 type State string
 

--- a/client/client.go
+++ b/client/client.go
@@ -30,7 +30,7 @@ func FromUser() (Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	path := filepath.Join(home, ".local", "share", "containers", "foxbox")
+	path := filepath.Join(home, ".local", "share", "containers", "foxbox", "v1")
 
 	err = os.MkdirAll(path, 0755)
 	if err != nil {

--- a/client/create.go
+++ b/client/create.go
@@ -12,11 +12,10 @@ import (
 
 type CreateOptions struct {
 	Image string
-	Store *store.Store
 }
 
-func (self *CreateOptions) GetImage() (f io.ReadCloser, gzipped bool, err error) {
-	path := self.Store.GetImagePath(self.Image, false)
+func (self *CreateOptions) GetImage(store *store.Store) (f io.ReadCloser, gzipped bool, err error) {
+	path := store.GetImagePath(self.Image, false)
 
 	f, err = os.Open(path)
 	if err != nil {
@@ -27,23 +26,16 @@ func (self *CreateOptions) GetImage() (f io.ReadCloser, gzipped bool, err error)
 	return
 }
 
-func Create(opt *CreateOptions) (name string, err error) {
+func (client *client) Create(opt *CreateOptions) (name string, err error) {
 	opt = newOr(opt)
 	name = NewName()
 
-	if opt.Store == nil {
-		opt.Store, err = store.New("runtime")
-		if err != nil {
-			return
-		}
-	}
-
-	entry, err := opt.Store.NewEntry(name)
+	entry, err := client.store.NewEntry(name)
 	if err != nil {
 		return
 	}
 
-	image, gzipped, err := opt.GetImage()
+	image, gzipped, err := opt.GetImage(client.store)
 	if err != nil {
 		entry.Delete()
 		return

--- a/client/delete.go
+++ b/client/delete.go
@@ -1,22 +1,10 @@
 package client
 
-import "github.com/codingpa-ws/foxbox/internal/store"
-
 type DeleteOptions struct {
-	Store *store.Store
 }
 
-func Delete(name string, opt *DeleteOptions) (err error) {
-	opt = newOr(opt)
-
-	if opt.Store == nil {
-		opt.Store, err = store.New("runtime")
-		if err != nil {
-			return
-		}
-	}
-
-	entry, err := opt.Store.GetEntry(name)
+func (client *client) Delete(name string, opt *DeleteOptions) (err error) {
+	entry, err := client.store.GetEntry(name)
 
 	if err != nil {
 		return

--- a/client/list.go
+++ b/client/list.go
@@ -2,25 +2,13 @@ package client
 
 import (
 	"os"
-
-	"github.com/codingpa-ws/foxbox/internal/store"
 )
 
 type ListOptions struct {
-	Store *store.Store
 }
 
-func List(opt *ListOptions) (ids []string, err error) {
-	opt = newOr(opt)
-
-	if opt.Store == nil {
-		opt.Store, err = store.New(RuntimeDir)
-		if err != nil {
-			return
-		}
-	}
-
-	path := opt.Store.EntryBase()
+func (client *client) List(opt *ListOptions) (ids []string, err error) {
+	path := client.store.EntryBase()
 
 	entries, err := os.ReadDir(path)
 	if err != nil {

--- a/client/ps.go
+++ b/client/ps.go
@@ -3,13 +3,10 @@ package client
 import (
 	"os"
 	"slices"
-
-	"github.com/codingpa-ws/foxbox/internal/store"
 )
 
 type PsOptions struct {
 	States []State
-	Store  *store.Store
 }
 
 type ProcessInfo struct {
@@ -19,17 +16,10 @@ type ProcessInfo struct {
 	ExitCode int
 }
 
-func Ps(opt *PsOptions) (infos []ProcessInfo, err error) {
+func (client *client) Ps(opt *PsOptions) (infos []ProcessInfo, err error) {
 	opt = newOr(opt)
 
-	if opt.Store == nil {
-		opt.Store, err = store.New("runtime")
-		if err != nil {
-			return
-		}
-	}
-
-	entries, err := os.ReadDir(opt.Store.EntryBase())
+	entries, err := os.ReadDir(client.store.EntryBase())
 	if err != nil {
 		return
 	}
@@ -38,7 +28,7 @@ func Ps(opt *PsOptions) (infos []ProcessInfo, err error) {
 			continue
 		}
 
-		entry, err := opt.Store.GetEntry(dir.Name())
+		entry, err := client.store.GetEntry(dir.Name())
 		if err != nil {
 			return nil, err
 		}

--- a/client/ps_test.go
+++ b/client/ps_test.go
@@ -13,16 +13,15 @@ func TestPs(t *testing.T) {
 	store, deleteStore := downloadImage(t)
 	defer deleteStore()
 
-	name, err := client.Create(&client.CreateOptions{
+	foxbox := client.FromStore(store)
+	name, err := foxbox.Create(&client.CreateOptions{
 		Image: AlpineImageName,
-		Store: store,
 	})
 	require.NoError(err)
 
 	runError := make(chan error)
 	go func() {
-		err = client.Run(name, &client.RunOptions{
-			Store:   store,
+		err = foxbox.Run(name, &client.RunOptions{
 			Command: []string{"sleep", "0.05"},
 		})
 		runError <- err
@@ -31,9 +30,7 @@ func TestPs(t *testing.T) {
 
 	time.Sleep(time.Millisecond * 10)
 
-	infos, err := client.Ps(&client.PsOptions{
-		Store: store,
-	})
+	infos, err := client.FromStore(store).Ps(nil)
 	require.NoError(err)
 	require.Equal(1, len(infos))
 	info := infos[0]

--- a/client/run.go
+++ b/client/run.go
@@ -27,7 +27,6 @@ type VolumeConfig struct {
 
 type RunOptions struct {
 	Command []string
-	Store   *store.Store
 
 	Stdin  io.Reader
 	Stdout io.Writer
@@ -73,17 +72,10 @@ func init() {
 	}
 }
 
-func Run(name string, opt *RunOptions) (err error) {
+func (client *client) Run(name string, opt *RunOptions) (err error) {
 	opt = newOr(opt)
 
-	if opt.Store == nil {
-		opt.Store, err = store.New("runtime")
-		if err != nil {
-			return
-		}
-	}
-
-	entry, err := opt.Store.GetEntry(name)
+	entry, err := client.store.GetEntry(name)
 	if err != nil {
 		return
 	}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1,15 +1,24 @@
 package cli
 
 import (
+	"fmt"
+
+	"github.com/codingpa-ws/foxbox/client"
 	"github.com/urfave/cli/v2"
 )
 
 var app = cli.NewApp()
+var foxbox client.Client
 
 func init() {
 	app.Usage = "A simple, cli-based container runtime"
 }
 
-func Start(args []string) error {
+func Start(args []string) (err error) {
+	foxbox, err = client.FromUser()
+	if err != nil {
+		return fmt.Errorf("initializing foxbox client: %w", err)
+	}
+
 	return app.Run(args)
 }

--- a/internal/cli/ls.go
+++ b/internal/cli/ls.go
@@ -3,8 +3,6 @@ package cli
 import (
 	"fmt"
 
-	"github.com/codingpa-ws/foxbox/client"
-
 	"github.com/urfave/cli/v2"
 )
 
@@ -17,7 +15,7 @@ func init() {
 }
 
 func ls(ctx *cli.Context) (err error) {
-	ids, err := client.List(nil)
+	ids, err := foxbox.List(nil)
 	if err != nil {
 		return
 	}

--- a/internal/cli/rm.go
+++ b/internal/cli/rm.go
@@ -3,8 +3,6 @@ package cli
 import (
 	"fmt"
 
-	"github.com/codingpa-ws/foxbox/client"
-
 	"github.com/urfave/cli/v2"
 )
 
@@ -19,7 +17,7 @@ func init() {
 
 func rm(ctx *cli.Context) (err error) {
 	for _, id := range ctx.Args().Slice() {
-		err := client.Delete(id, nil)
+		err := foxbox.Delete(id, nil)
 		if err != nil {
 			return fmt.Errorf("removing %s: %w", id, err)
 		}

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -77,7 +77,7 @@ func run(ctx *cli.Context) (err error) {
 		}
 	}
 
-	id, err := client.Create(&client.CreateOptions{
+	id, err := foxbox.Create(&client.CreateOptions{
 		Image: args.First(),
 	})
 
@@ -87,14 +87,14 @@ func run(ctx *cli.Context) (err error) {
 
 	if ctx.Bool("rm") {
 		defer func() {
-			err := client.Delete(id, nil)
+			err := foxbox.Delete(id, nil)
 			if err != nil {
 				log.Printf("failed to delete foxbox %s: %s\n", id, err)
 			}
 		}()
 	}
 
-	err = client.Run(id, &client.RunOptions{
+	err = foxbox.Run(id, &client.RunOptions{
 		Command:          args.Slice()[1:],
 		EnableNetworking: true,
 		MaxMemoryBytes:   uint(v.Bytes()),


### PR DESCRIPTION
This switches the client to using a persistent client object, similar to how an SQL client would work in Go.

We need this if we want to implement a different backend (e.g. a daemon) in foxbox. It also simplifies using the store by putting it into the client and offering a sensible default.

## Before

```go
id, err := client.Create(&client.CreateOptions{
	Image: "alpine",
})
```

## After

```go
foxbox, err := client.FromUser()
if err != nil {
	return err
}
id, err := foxbox.Create(&client.CreateOptions{
	Image: "alpine",
})
```