### PR TITLE
Refactor seccomp rules

### DIFF
--- a/client/run.go
+++ b/client/run.go
@@ -341,145 +341,122 @@ func enterFs() (err error) {
 }
 
 func dropSyscalls() error {
-	var SCMP_FAIL = seccomp.ActErrno.SetReturnCode(int16(unix.EPERM))
+	actionFail := seccomp.ActErrno.SetReturnCode(int16(unix.EPERM))
 	filter, err := seccomp.NewFilter(seccomp.ActAllow)
 	if err != nil {
 		return fmt.Errorf("creating seccomp filter: %w", err)
 	}
 	defer filter.Release()
 
-	name := "chmod"
-	call, err := seccomp.GetSyscallFromName(name)
-	if err != nil {
-		return fmt.Errorf("getting syscall `%s`: %w", name, err)
-	}
-	err = filter.AddRuleConditional(call, SCMP_FAIL, []seccomp.ScmpCondition{
+	rules := []struct {
+		syscall   string
+		action    seccomp.ScmpAction
+		condition seccomp.ScmpCondition
+	}{
 		{
-			Argument: 1,
-			Operand1: syscall.S_ISUID,
-			Operand2: syscall.S_ISUID,
-			Op:       seccomp.CompareMaskedEqual,
+			syscall: "chmod",
+			action:  actionFail,
+			condition: seccomp.ScmpCondition{
+				Argument: 1,
+				Operand1: syscall.S_ISUID,
+				Operand2: syscall.S_ISUID,
+				Op:       seccomp.CompareMaskedEqual,
+			},
 		},
-	})
-	if err != nil {
-		return fmt.Errorf("adding rule for %s: %w", name, err)
-	}
-	err = filter.AddRuleConditional(call, SCMP_FAIL, []seccomp.ScmpCondition{
 		{
-			Argument: 1,
-			Operand1: syscall.S_ISGID,
-			Operand2: syscall.S_ISGID,
-			Op:       seccomp.CompareMaskedEqual,
+			syscall: "chmod",
+			action:  actionFail,
+			condition: seccomp.ScmpCondition{
+				Argument: 1,
+				Operand1: syscall.S_ISGID,
+				Operand2: syscall.S_ISGID,
+				Op:       seccomp.CompareMaskedEqual,
+			},
 		},
-	})
-	if err != nil {
-		return fmt.Errorf("adding rule for %s: %w", name, err)
-	}
-	name = "fchmod"
-	call, err = seccomp.GetSyscallFromName(name)
-	if err != nil {
-		return fmt.Errorf("getting syscall `%s`: %w", name, err)
-	}
-	err = filter.AddRuleConditional(call, SCMP_FAIL, []seccomp.ScmpCondition{
 		{
-			Argument: 1,
-			Operand1: syscall.S_ISUID,
-			Operand2: syscall.S_ISUID,
-			Op:       seccomp.CompareMaskedEqual,
+			syscall: "fchmod",
+			action:  actionFail,
+			condition: seccomp.ScmpCondition{
+				Argument: 1,
+				Operand1: syscall.S_ISUID,
+				Operand2: syscall.S_ISUID,
+				Op:       seccomp.CompareMaskedEqual,
+			},
 		},
-	})
-	if err != nil {
-		return fmt.Errorf("adding rule for %s: %w", name, err)
-	}
-	err = filter.AddRuleConditional(call, SCMP_FAIL, []seccomp.ScmpCondition{
 		{
-			Argument: 1,
-			Operand1: syscall.S_ISGID,
-			Operand2: syscall.S_ISGID,
-			Op:       seccomp.CompareMaskedEqual,
+			syscall: "fchmod",
+			action:  actionFail,
+			condition: seccomp.ScmpCondition{
+				Argument: 1,
+				Operand1: syscall.S_ISGID,
+				Operand2: syscall.S_ISGID,
+				Op:       seccomp.CompareMaskedEqual,
+			},
 		},
-	})
-	if err != nil {
-		return fmt.Errorf("adding rule for %s: %w", name, err)
+		{
+			syscall: "fchmodat",
+			action:  actionFail,
+			condition: seccomp.ScmpCondition{
+				Argument: 2,
+				Operand1: syscall.S_ISUID,
+				Operand2: syscall.S_ISUID,
+				Op:       seccomp.CompareMaskedEqual,
+			},
+		},
+		{
+			syscall: "fchmodat",
+			action:  actionFail,
+			condition: seccomp.ScmpCondition{
+				Argument: 2,
+				Operand1: syscall.S_ISGID,
+				Operand2: syscall.S_ISGID,
+				Op:       seccomp.CompareMaskedEqual,
+			},
+		},
+		{
+			syscall: "unshare",
+			action:  actionFail,
+			condition: seccomp.ScmpCondition{
+				Argument: 0,
+				Operand1: syscall.CLONE_NEWUSER,
+				Operand2: syscall.CLONE_NEWUSER,
+				Op:       seccomp.CompareMaskedEqual,
+			},
+		},
+		{
+			syscall: "clone",
+			action:  actionFail,
+			condition: seccomp.ScmpCondition{
+				Argument: 0,
+				Operand1: syscall.CLONE_NEWUSER,
+				Operand2: syscall.CLONE_NEWUSER,
+				Op:       seccomp.CompareMaskedEqual,
+			},
+		},
+		{
+			syscall: "ioctl",
+			action:  actionFail,
+			condition: seccomp.ScmpCondition{
+				Argument: 0,
+				Operand1: syscall.CLONE_NEWUSER,
+				Operand2: syscall.CLONE_NEWUSER,
+				Op:       seccomp.CompareMaskedEqual,
+			},
+		},
 	}
 
-	name = "fchmodat"
-	call, err = seccomp.GetSyscallFromName(name)
-	if err != nil {
-		return fmt.Errorf("getting syscall `%s`: %w", name, err)
-	}
-	err = filter.AddRuleConditional(call, SCMP_FAIL, []seccomp.ScmpCondition{
-		{
-			Argument: 2,
-			Operand1: syscall.S_ISUID,
-			Operand2: syscall.S_ISUID,
-			Op:       seccomp.CompareMaskedEqual,
-		},
-	})
-	if err != nil {
-		return fmt.Errorf("adding rule for %s: %w", name, err)
-	}
-	err = filter.AddRuleConditional(call, SCMP_FAIL, []seccomp.ScmpCondition{
-		{
-			Argument: 2,
-			Operand1: syscall.S_ISGID,
-			Operand2: syscall.S_ISGID,
-			Op:       seccomp.CompareMaskedEqual,
-		},
-	})
-	if err != nil {
-		return fmt.Errorf("adding rule for %s: %w", name, err)
-	}
+	for _, rule := range rules {
+		call, err := seccomp.GetSyscallFromName(rule.syscall)
+		if err != nil {
+			return fmt.Errorf("getting syscall `%s`: %w", rule.syscall, err)
+		}
 
-	name = "unshare"
-	call, err = seccomp.GetSyscallFromName("unshare")
-	if err != nil {
-		return fmt.Errorf("getting syscall `%s`: %w", name, err)
-	}
-	err = filter.AddRuleConditional(call, SCMP_FAIL, []seccomp.ScmpCondition{
-		{
-			Argument: 0,
-			Operand1: syscall.CLONE_NEWUSER,
-			Operand2: syscall.CLONE_NEWUSER,
-			Op:       seccomp.CompareMaskedEqual,
-		},
-	})
-	if err != nil {
-		return fmt.Errorf("adding rule for %s: %w", name, err)
-	}
-
-	name = "clone"
-	call, err = seccomp.GetSyscallFromName(name)
-	if err != nil {
-		return fmt.Errorf("getting syscall `%s`: %w", name, err)
-	}
-	err = filter.AddRuleConditional(call, SCMP_FAIL, []seccomp.ScmpCondition{
-		{
-			Argument: 0,
-			Operand1: syscall.CLONE_NEWUSER,
-			Operand2: syscall.CLONE_NEWUSER,
-			Op:       seccomp.CompareMaskedEqual,
-		},
-	})
-	if err != nil {
-		return fmt.Errorf("adding rule for %s: %w", name, err)
-	}
-
-	name = "ioctl"
-	call, err = seccomp.GetSyscallFromName(name)
-	if err != nil {
-		return fmt.Errorf("getting syscall `%s`: %w", name, err)
-	}
-	err = filter.AddRuleConditional(call, SCMP_FAIL, []seccomp.ScmpCondition{
-		{
-			Argument: 0,
-			Operand1: syscall.CLONE_NEWUSER,
-			Operand2: syscall.CLONE_NEWUSER,
-			Op:       seccomp.CompareMaskedEqual,
-		},
-	})
-	if err != nil {
-		return fmt.Errorf("adding rule for %s: %w", name, err)
+		err = filter.AddRuleConditional(call, rule.action, []seccomp.ScmpCondition{
+			rule.condition,
+		})
+		if err != nil {
+			return fmt.Errorf("adding rule for %s: %w", rule.syscall, err)
+		}
 	}
 
 	err = filter.SetNoNewPrivsBit(false)
@@ -507,7 +484,7 @@ func dropSyscalls() error {
 		if err != nil {
 			return fmt.Errorf("getting syscall `%s`: %w", name, err)
 		}
-		err = filter.AddRule(call, SCMP_FAIL)
+		err = filter.AddRule(call, actionFail)
 
 		if err != nil {
 			return fmt.Errorf("adding rule for `%s`: %w", name, err)


### PR DESCRIPTION
This refactors the rules part of the `dropSyscall` function to use a list of rules instead of hardcoding all rules repetitively.
