### PR TITLE
Move security-related code to separate module

### DIFF
--- a/internal/security/capabilities.go
+++ b/internal/security/capabilities.go
@@ -1,0 +1,46 @@
+package security
+
+import (
+	"fmt"
+
+	"golang.org/x/sys/unix"
+)
+
+// Uses prctl(PR_CAPBSET_DROP) to drop capabilities from the process’
+// capability bounding set.
+//
+// See capabilities(7) for a list of all available capabilities
+func DropCapabilities() error {
+	caps := []uintptr{
+		unix.CAP_AUDIT_CONTROL,
+		unix.CAP_AUDIT_READ,
+		unix.CAP_AUDIT_WRITE,
+		unix.CAP_BLOCK_SUSPEND,
+		unix.CAP_DAC_READ_SEARCH,
+		unix.CAP_FSETID,
+		unix.CAP_IPC_LOCK,
+		unix.CAP_MAC_ADMIN,
+		unix.CAP_MAC_OVERRIDE,
+		unix.CAP_MKNOD,
+		unix.CAP_SETFCAP,
+		unix.CAP_SYSLOG,
+		unix.CAP_SYS_ADMIN,
+		unix.CAP_SYS_BOOT,
+		unix.CAP_SYS_MODULE,
+		unix.CAP_SYS_NICE,
+		unix.CAP_SYS_RAWIO,
+		unix.CAP_SYS_RESOURCE,
+		unix.CAP_SYS_TIME,
+		unix.CAP_WAKE_ALARM,
+	}
+
+	for _, cap := range caps {
+		err := unix.Prctl(unix.PR_CAPBSET_DROP, cap, 0, 0, 0)
+
+		if err != nil {
+			return fmt.Errorf("dropping capability %#x: %w", cap, err)
+		}
+	}
+
+	return nil
+}

--- a/internal/security/syscalls.go
+++ b/internal/security/syscalls.go
@@ -1,0 +1,163 @@
+package security
+
+import (
+	"fmt"
+	"syscall"
+
+	seccomp "github.com/seccomp/libseccomp-golang"
+	"golang.org/x/sys/unix"
+)
+
+var forbiddenSyscalls = []string{
+	"keyctl",
+	"add_key",
+	"request_key",
+	"ptrace",
+	"mbind",
+	"migrate_pages",
+	"move_pages",
+	"set_mempolicy",
+	"userfaultfd",
+	"perf_event_open",
+	"chroot",
+}
+
+func RestrictSyscalls() error {
+	actionFail := seccomp.ActErrno.SetReturnCode(int16(unix.EPERM))
+	filter, err := seccomp.NewFilter(seccomp.ActAllow)
+	if err != nil {
+		return fmt.Errorf("creating seccomp filter: %w", err)
+	}
+	defer filter.Release()
+
+	rules := []struct {
+		syscall   string
+		action    seccomp.ScmpAction
+		condition seccomp.ScmpCondition
+	}{
+		{
+			syscall: "chmod",
+			action:  actionFail,
+			condition: seccomp.ScmpCondition{
+				Argument: 1,
+				Operand1: syscall.S_ISUID,
+				Operand2: syscall.S_ISUID,
+				Op:       seccomp.CompareMaskedEqual,
+			},
+		},
+		{
+			syscall: "chmod",
+			action:  actionFail,
+			condition: seccomp.ScmpCondition{
+				Argument: 1,
+				Operand1: syscall.S_ISGID,
+				Operand2: syscall.S_ISGID,
+				Op:       seccomp.CompareMaskedEqual,
+			},
+		},
+		{
+			syscall: "fchmod",
+			action:  actionFail,
+			condition: seccomp.ScmpCondition{
+				Argument: 1,
+				Operand1: syscall.S_ISUID,
+				Operand2: syscall.S_ISUID,
+				Op:       seccomp.CompareMaskedEqual,
+			},
+		},
+		{
+			syscall: "fchmod",
+			action:  actionFail,
+			condition: seccomp.ScmpCondition{
+				Argument: 1,
+				Operand1: syscall.S_ISGID,
+				Operand2: syscall.S_ISGID,
+				Op:       seccomp.CompareMaskedEqual,
+			},
+		},
+		{
+			syscall: "fchmodat",
+			action:  actionFail,
+			condition: seccomp.ScmpCondition{
+				Argument: 2,
+				Operand1: syscall.S_ISUID,
+				Operand2: syscall.S_ISUID,
+				Op:       seccomp.CompareMaskedEqual,
+			},
+		},
+		{
+			syscall: "fchmodat",
+			action:  actionFail,
+			condition: seccomp.ScmpCondition{
+				Argument: 2,
+				Operand1: syscall.S_ISGID,
+				Operand2: syscall.S_ISGID,
+				Op:       seccomp.CompareMaskedEqual,
+			},
+		},
+		{
+			syscall: "unshare",
+			action:  actionFail,
+			condition: seccomp.ScmpCondition{
+				Argument: 0,
+				Operand1: syscall.CLONE_NEWUSER,
+				Operand2: syscall.CLONE_NEWUSER,
+				Op:       seccomp.CompareMaskedEqual,
+			},
+		},
+		{
+			syscall: "clone",
+			action:  actionFail,
+			condition: seccomp.ScmpCondition{
+				Argument: 0,
+				Operand1: syscall.CLONE_NEWUSER,
+				Operand2: syscall.CLONE_NEWUSER,
+				Op:       seccomp.CompareMaskedEqual,
+			},
+		},
+		{
+			syscall: "ioctl",
+			action:  actionFail,
+			condition: seccomp.ScmpCondition{
+				Argument: 0,
+				Operand1: syscall.CLONE_NEWUSER,
+				Operand2: syscall.CLONE_NEWUSER,
+				Op:       seccomp.CompareMaskedEqual,
+			},
+		},
+	}
+
+	for _, rule := range rules {
+		call, err := seccomp.GetSyscallFromName(rule.syscall)
+		if err != nil {
+			return fmt.Errorf("getting syscall `%s`: %w", rule.syscall, err)
+		}
+
+		err = filter.AddRuleConditional(call, rule.action, []seccomp.ScmpCondition{
+			rule.condition,
+		})
+		if err != nil {
+			return fmt.Errorf("adding rule for %s: %w", rule.syscall, err)
+		}
+	}
+
+	err = filter.SetNoNewPrivsBit(false)
+	if err != nil {
+		return fmt.Errorf("setting SCMP_FLTATR_CTL_NNP: %w", err)
+	}
+
+	for _, name := range forbiddenSyscalls {
+		call, err := seccomp.GetSyscallFromName(name)
+
+		if err != nil {
+			return fmt.Errorf("getting syscall `%s`: %w", name, err)
+		}
+		err = filter.AddRule(call, actionFail)
+
+		if err != nil {
+			return fmt.Errorf("adding rule for `%s`: %w", name, err)
+		}
+	}
+
+	return filter.Load()
+}

--- a/internal/security/sysprocattr.go
+++ b/internal/security/sysprocattr.go
@@ -1,0 +1,29 @@
+package security
+
+import (
+	"fmt"
+	"syscall"
+)
+
+func GetSysProcAttr(fd int, useCgroupFD bool) (*syscall.SysProcAttr, error) {
+	uid, gid, err := GetUserIdentifiers()
+	if err != nil {
+		return nil, fmt.Errorf("getting uid/gid: %w", err)
+	}
+
+	return &syscall.SysProcAttr{
+		Cloneflags:   syscall.CLONE_NEWUTS | syscall.CLONE_NEWUSER | syscall.CLONE_NEWNS | syscall.CLONE_NEWIPC | syscall.CLONE_NEWPID | syscall.CLONE_NEWNET | syscall.CLONE_NEWTIME | syscall.CLONE_NEWCGROUP,
+		Unshareflags: syscall.CLONE_NEWNS,
+		UidMappings: []syscall.SysProcIDMap{{
+			ContainerID: 0,
+			HostID:      int(uid),
+			Size:        1}},
+		GidMappings: []syscall.SysProcIDMap{{
+			ContainerID: 0,
+			HostID:      int(gid),
+			Size:        1,
+		}},
+		CgroupFD:    fd,
+		UseCgroupFD: useCgroupFD,
+	}, nil
+}

--- a/internal/security/uids.go
+++ b/internal/security/uids.go
@@ -1,0 +1,25 @@
+package security
+
+import (
+	"fmt"
+	"os/user"
+	"strconv"
+)
+
+func GetUserIdentifiers() (uid, gid int, err error) {
+	user, err := user.Current()
+	if err != nil {
+		return 0, 0, fmt.Errorf("getting current user: %w", err)
+	}
+
+	uid, err = strconv.Atoi(user.Uid)
+	if err != nil {
+		return 0, 0, fmt.Errorf("parsing user uid (%s): %w", user.Uid, err)
+	}
+	gid, err = strconv.Atoi(user.Gid)
+	if err != nil {
+		return 0, 0, fmt.Errorf("parsing user gid (%s): %w", user.Gid, err)
+	}
+
+	return
+}


### PR DESCRIPTION
This moves security-related code, except for most cgroup-related parts, to a separate `internal/security` module, so it is easier to review and change.
