### PR TITLE
Add shep to hostname subjects

### DIFF
--- a/client/names.go
+++ b/client/names.go
@@ -33,6 +33,7 @@ var subjects = []string{
 	"proto",
 	"bunny",
 	"yeen",
+	"shep",
 }
 
 var random = rand.New(rand.NewSource(time.Now().UnixNano()))


### PR DESCRIPTION
By popular request (by @sniff122), this adds `shep` to the hostname subjects.
